### PR TITLE
fixed typos / URI conventions

### DIFF
--- a/Ontologie/l0/latest/l0-AP_IT.ttl
+++ b/Ontologie/l0/latest/l0-AP_IT.ttl
@@ -9,7 +9,7 @@
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @base <https://w3id.org/italia/onto/l0/> .
 
-<https://w3id.org/italia/onto/l0/> rdf:type owl:Ontology ;
+<https://w3id.org/italia/onto/l0> rdf:type owl:Ontology ;
                                    
                                    rdfs:label "Level-0 ontology"@en ,
                                               "Ontologia Level-0"@it ;
@@ -35,7 +35,7 @@
                                    
                                    dc:creator "Team per la Trasformazione Digitale"@it ;
                                    
-                                   prov:wasDerivedFrom <http://dati.gov.it/onto/l0/> ;
+                                   prov:wasDerivedFrom <https://w3id.org/italia/onto/l0> ;
                                    
                                    prov:wasInfluencedBy <http://www.ontologydesignpatterns.org/ont/d0.owl> ;
                                    
@@ -97,7 +97,7 @@ prov:wasInfluencedBy rdf:type owl:AnnotationProperty .
                 
                 owl:versionInfo "stabile"@it ;
                 
-                rdfs:isDefinedBy <http://dati.gov.it/onto/l0/> ;
+                rdfs:isDefinedBy <https://w3id.org/italia/onto/l0> ;
                 
                 rdfs:domain owl:Thing ;
                 
@@ -122,7 +122,7 @@ prov:wasInfluencedBy rdf:type owl:AnnotationProperty .
                  
                  owl:versionInfo "stabile"@it ;
                  
-                 rdfs:isDefinedBy <http://dati.gov.it/onto/l0/> ;
+                 rdfs:isDefinedBy <https://w3id.org/italia/onto/l0> ;
                  
                  rdfs:range owl:Thing ;
                  
@@ -154,7 +154,7 @@ prov:wasInfluencedBy rdf:type owl:AnnotationProperty .
              
              owl:versionInfo "stabile"@it ;
              
-             rdfs:isDefinedBy <http://dati.gov.it/onto/l0/> ;
+             rdfs:isDefinedBy <https://w3id.org/italia/onto/l0> ;
              
              rdfs:range rdfs:Literal ;
              
@@ -177,7 +177,7 @@ prov:wasInfluencedBy rdf:type owl:AnnotationProperty .
             
             owl:versionInfo "stabile"@it ;
             
-            rdfs:isDefinedBy <http://dati.gov.it/onto/l0/> ;
+            rdfs:isDefinedBy <https://w3id.org/italia/onto/l0> ;
             
             rdfs:range rdfs:Literal ;
             
@@ -200,7 +200,7 @@ prov:wasInfluencedBy rdf:type owl:AnnotationProperty .
       
       owl:versionInfo "stabile"@it ;
       
-      rdfs:isDefinedBy <http://dati.gov.it/onto/l0/> ;
+      rdfs:isDefinedBy <https://w3id.org/italia/onto/l0> ;
       
       rdfs:range rdfs:Literal ;
       
@@ -234,7 +234,7 @@ prov:wasInfluencedBy rdf:type owl:AnnotationProperty .
           
           owl:versionInfo "stabile"@it ;
           
-          rdfs:isDefinedBy <http://dati.gov.it/onto/l0/> .
+          rdfs:isDefinedBy <https://w3id.org/italia/onto/l0> .
 
 
 
@@ -255,7 +255,7 @@ prov:wasInfluencedBy rdf:type owl:AnnotationProperty .
        
        owl:versionInfo "stabile"@it ;
        
-       rdfs:isDefinedBy <http://dati.gov.it/onto/l0/> .
+       rdfs:isDefinedBy <https://w3id.org/italia/onto/l0> .
 
 
 
@@ -276,7 +276,7 @@ prov:wasInfluencedBy rdf:type owl:AnnotationProperty .
                 
                 owl:versionInfo "stabile"@it ;
                 
-                rdfs:isDefinedBy <http://dati.gov.it/onto/l0/> .
+                rdfs:isDefinedBy <https://w3id.org/italia/onto/l0> .
 
 
 
@@ -297,7 +297,7 @@ prov:wasInfluencedBy rdf:type owl:AnnotationProperty .
             
             owl:versionInfo "stabile"@it ;
             
-            rdfs:isDefinedBy <http://dati.gov.it/onto/l0/> .
+            rdfs:isDefinedBy <https://w3id.org/italia/onto/l0> .
 
 
 
@@ -324,7 +324,7 @@ Gli esempi includono i piani (come descrizioni strutturate di azioni da eseguire
              
              owl:versionInfo "stabile"@it ;
              
-             rdfs:isDefinedBy <http://dati.gov.it/onto/l0/> .
+             rdfs:isDefinedBy <https://w3id.org/italia/onto/l0> .
 
 
 
@@ -343,7 +343,7 @@ Gli esempi includono i piani (come descrizioni strutturate di azioni da eseguire
         
         owl:versionInfo "stabile"@it ;
         
-        rdfs:isDefinedBy <http://dati.gov.it/onto/l0/> .
+        rdfs:isDefinedBy <https://w3id.org/italia/onto/l0> .
 
 
 
@@ -368,7 +368,7 @@ Gli eventi si oppongono agli oggetti, poiché, mentre gli eventi scorrono nel te
        
        owl:versionInfo "stabile"@it ;
        
-       rdfs:isDefinedBy <http://dati.gov.it/onto/l0/> .
+       rdfs:isDefinedBy <https://w3id.org/italia/onto/l0> .
 
 
 
@@ -389,7 +389,7 @@ Gli eventi si oppongono agli oggetti, poiché, mentre gli eventi scorrono nel te
           
           owl:versionInfo "stabile"@it ;
           
-          rdfs:isDefinedBy <http://dati.gov.it/onto/l0/> .
+          rdfs:isDefinedBy <https://w3id.org/italia/onto/l0> .
 
 
 
@@ -412,7 +412,7 @@ GLi oggetti si possono contrapporre agli eventi, che invece scorrono nel tempo, 
         
         owl:versionInfo "stabile"@it ;
         
-        rdfs:isDefinedBy <http://dati.gov.it/onto/l0/> .
+        rdfs:isDefinedBy <https://w3id.org/italia/onto/l0> .
 
 
 
@@ -433,7 +433,7 @@ GLi oggetti si possono contrapporre agli eventi, che invece scorrono nel tempo, 
         
         owl:versionInfo "stabile"@it ;
         
-        rdfs:isDefinedBy <http://dati.gov.it/onto/l0/> .
+        rdfs:isDefinedBy <https://w3id.org/italia/onto/l0> .
 
 
 
@@ -454,7 +454,7 @@ GLi oggetti si possono contrapporre agli eventi, che invece scorrono nel tempo, 
        
        owl:versionInfo "stabile"@it ;
        
-       rdfs:isDefinedBy <http://dati.gov.it/onto/l0/> .
+       rdfs:isDefinedBy <https://w3id.org/italia/onto/l0> .
 
 
 

--- a/Ontologie/l0/latest/l0-AP_IT.ttl
+++ b/Ontologie/l0/latest/l0-AP_IT.ttl
@@ -14,11 +14,11 @@
                                    rdfs:label "Level-0 ontology"@en ,
                                               "Ontologia Level-0"@it ;
                                    
-                                   dct:modified "2018-02-01" ;
+                                   dct:modified "2018-06-11" ;
                                    
                                    dct:issued "2017-09-29" ;
                                    
-                                   owl:versionInfo "0.3 - 01 February 2018 - refactoring of the main classes and alignment with DOLCE 0"@en ;
+                                   owl:versionInfo "0.5 - 11 June 2018 - refactoring of the URI conventions, using w3id.org"@en ;
                                    
                                    dc:creator "Agency for Digital Italy - AgID"@en ,
                                               "Institute of Cognitive Sciences and Technologies of the Italian Research Council (CNR) - Semantic Technology Laboratory (STLab)"@en ,
@@ -26,7 +26,7 @@
                                    
                                    rdfs:comment "This ontology provides the foundational level of the ontological stack of OntoPiA. The name L0 stands for Level-0 ontology as it provides the basic conceptual foundations to the whole stack. This ontology is inspired by DOLCE 0 (http://www.ontologydesignpatterns.org/ont/d0.owl)"@en ;
                                    
-                                   owl:versionInfo "0.3 - 01 Febbraio 2018 - rifattorizzazione della classi principali e allineamento a DOLCE 0"@it ;
+                                   owl:versionInfo "0.5 - 11 Giugno 2018 - rifattorizzazione delle convenzioni sugli URI, conn l'utilizzo di w3id.org"@it ;
                                    
                                    dc:creator "Agenzia per l'Italia Digitale"@it ,
                                               "Istituto di Scienze e Tecnologie della Cognizione del CNR - Laboratorio di tecnologie semantiche (STLab)"@it ;
@@ -39,7 +39,7 @@
                                    
                                    prov:wasInfluencedBy <http://www.ontologydesignpatterns.org/ont/d0.owl> ;
                                    
-                                   owl:versionIRI <https://w3id.org/italia/onto/l0/0.4/> .
+                                   owl:versionIRI <https://w3id.org/italia/onto/l0/0.5/> .
 
 
 #################################################################


### PR DESCRIPTION
some minor fixes were needed to avoid problems in URI from other ontologies:
+ updated all old URI `<http://dati.gov.it/onto/l0/>` to the current convention `<https://w3id.org/italia/onto/l0>`
+ fixed conventional URI for l0: 
`<https://w3id.org/italia/onto/l0/> a owl:Ontology .` to `<https://w3id.org/italia/onto/l0> a owl:Ontology .`