### PR TITLE
minor fixes in URI: dati.gov.it to w3id.org

### DIFF
--- a/Ontologie/l0/latest/l0-aligns-AP_IT.ttl
+++ b/Ontologie/l0/latest/l0-aligns-AP_IT.ttl
@@ -1,16 +1,16 @@
-@prefix : <http://dati.gov.it/onto/l0-aligns/> .
+@prefix : <https://w3id.org/italia/onto/l0-aligns/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix xml: <http://www.w3.org/XML/1998/namespace> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
-@base <http://dati.gov.it/onto/l0-aligns/> .
+@base <https://w3id.org/italia/onto/l0-aligns/> .
 
-<http://dati.gov.it/onto/l0-aligns/> rdf:type owl:Ontology ;
+<https://w3id.org/italia/onto/l0-aligns> rdf:type owl:Ontology ;
                                      
-                                     owl:versionIRI <http://dati.gov.it/onto/l0-aligns/0.4> ;
+                                     owl:versionIRI <https://w3id.org/italia/onto/l0-aligns/0.5> ;
                                      
-                                     owl:imports <http://dati.gov.it/onto/l0/> ,
+                                     owl:imports <https://w3id.org/italia/onto/l0> ,
                                                  <http://www.ontologydesignpatterns.org/ont/d0.owl> .
 
 
@@ -21,15 +21,15 @@
 #################################################################
 
 
-###  http://dati.gov.it/onto/l0/hasDescription
+###  https://w3id.org/italia/onto/l0/hasDescription
 
-<http://dati.gov.it/onto/l0/hasDescription> owl:equivalentProperty <http://www.ontologydesignpatterns.org/ont/dul/DUL.owl#isDescribedBy> .
+<https://w3id.org/italia/onto/l0/hasDescription> owl:equivalentProperty <http://www.ontologydesignpatterns.org/ont/dul/DUL.owl#isDescribedBy> .
 
 
 
-###  http://dati.gov.it/onto/l0/isDescriptionOf
+###  https://w3id.org/italia/onto/l0/isDescriptionOf
 
-<http://dati.gov.it/onto/l0/isDescriptionOf> owl:equivalentProperty <http://www.ontologydesignpatterns.org/ont/dul/DUL.owl#describes> .
+<https://w3id.org/italia/onto/l0/isDescriptionOf> owl:equivalentProperty <http://www.ontologydesignpatterns.org/ont/dul/DUL.owl#describes> .
 
 
 
@@ -52,21 +52,21 @@
 #################################################################
 
 
-###  http://dati.gov.it/onto/l0/description
+###  https://w3id.org/italia/onto/l0/description
 
-<http://dati.gov.it/onto/l0/description> rdfs:subPropertyOf <http://www.ontologydesignpatterns.org/ont/dul/DUL.owl#hasDataValue> .
-
-
-
-###  http://dati.gov.it/onto/l0/identifier
-
-<http://dati.gov.it/onto/l0/identifier> rdfs:subPropertyOf <http://www.ontologydesignpatterns.org/ont/dul/DUL.owl#hasDataValue> .
+<https://w3id.org/italia/onto/l0/description> rdfs:subPropertyOf <http://www.ontologydesignpatterns.org/ont/dul/DUL.owl#hasDataValue> .
 
 
 
-###  http://dati.gov.it/onto/l0/name
+###  https://w3id.org/italia/onto/l0/identifier
 
-<http://dati.gov.it/onto/l0/name> rdfs:subPropertyOf <http://www.ontologydesignpatterns.org/ont/dul/DUL.owl#hasDataValue> .
+<https://w3id.org/italia/onto/l0/identifier> rdfs:subPropertyOf <http://www.ontologydesignpatterns.org/ont/dul/DUL.owl#hasDataValue> .
+
+
+
+###  https://w3id.org/italia/onto/l0/name
+
+<https://w3id.org/italia/onto/l0/name> rdfs:subPropertyOf <http://www.ontologydesignpatterns.org/ont/dul/DUL.owl#hasDataValue> .
 
 
 
@@ -79,69 +79,69 @@
 #################################################################
 
 
-###  http://dati.gov.it/onto/l0/Activity
+###  https://w3id.org/italia/onto/l0/Activity
 
-<http://dati.gov.it/onto/l0/Activity> owl:equivalentClass <http://www.ontologydesignpatterns.org/ont/d0.owl#Activity> .
-
-
-
-###  http://dati.gov.it/onto/l0/Agent
-
-<http://dati.gov.it/onto/l0/Agent> owl:equivalentClass <http://www.ontologydesignpatterns.org/ont/dul/DUL.owl#Agent> .
+<https://w3id.org/italia/onto/l0/Activity> owl:equivalentClass <http://www.ontologydesignpatterns.org/ont/d0.owl#Activity> .
 
 
 
-###  http://dati.gov.it/onto/l0/Characteristic
+###  https://w3id.org/italia/onto/l0/Agent
 
-<http://dati.gov.it/onto/l0/Characteristic> owl:equivalentClass <http://www.ontologydesignpatterns.org/ont/d0.owl#Characteristic> .
-
-
-
-###  http://dati.gov.it/onto/l0/Collection
-
-<http://dati.gov.it/onto/l0/Collection> owl:equivalentClass <http://www.ontologydesignpatterns.org/ont/dul/DUL.owl#Collection> .
+<https://w3id.org/italia/onto/l0/Agent> owl:equivalentClass <http://www.ontologydesignpatterns.org/ont/dul/DUL.owl#Agent> .
 
 
 
-###  http://dati.gov.it/onto/l0/Description
+###  https://w3id.org/italia/onto/l0/Characteristic
 
-<http://dati.gov.it/onto/l0/Description> owl:equivalentClass <http://www.ontologydesignpatterns.org/ont/dul/DUL.owl#Description> .
-
-
-
-###  http://dati.gov.it/onto/l0/Entity
-
-<http://dati.gov.it/onto/l0/Entity> owl:equivalentClass <http://www.ontologydesignpatterns.org/ont/dul/DUL.owl#Entity> .
+<https://w3id.org/italia/onto/l0/Characteristic> owl:equivalentClass <http://www.ontologydesignpatterns.org/ont/d0.owl#Characteristic> .
 
 
 
-###  http://dati.gov.it/onto/l0/Event
+###  https://w3id.org/italia/onto/l0/Collection
 
-<http://dati.gov.it/onto/l0/Event> owl:equivalentClass <http://www.ontologydesignpatterns.org/ont/dul/DUL.owl#Event> .
-
-
-
-###  http://dati.gov.it/onto/l0/Location
-
-<http://dati.gov.it/onto/l0/Location> owl:equivalentClass <http://www.ontologydesignpatterns.org/ont/d0.owl#Location> .
+<https://w3id.org/italia/onto/l0/Collection> owl:equivalentClass <http://www.ontologydesignpatterns.org/ont/dul/DUL.owl#Collection> .
 
 
 
-###  http://dati.gov.it/onto/l0/Object
+###  https://w3id.org/italia/onto/l0/Description
 
-<http://dati.gov.it/onto/l0/Object> owl:equivalentClass <http://www.ontologydesignpatterns.org/ont/dul/DUL.owl#Object> .
-
-
-
-###  http://dati.gov.it/onto/l0/System
-
-<http://dati.gov.it/onto/l0/System> owl:equivalentClass <http://www.ontologydesignpatterns.org/ont/d0.owl#System> .
+<https://w3id.org/italia/onto/l0/Description> owl:equivalentClass <http://www.ontologydesignpatterns.org/ont/dul/DUL.owl#Description> .
 
 
 
-###  http://dati.gov.it/onto/l0/Topic
+###  https://w3id.org/italia/onto/l0/Entity
 
-<http://dati.gov.it/onto/l0/Topic> owl:equivalentClass <http://www.ontologydesignpatterns.org/ont/d0.owl#Topic> .
+<https://w3id.org/italia/onto/l0/Entity> owl:equivalentClass <http://www.ontologydesignpatterns.org/ont/dul/DUL.owl#Entity> .
+
+
+
+###  https://w3id.org/italia/onto/l0/Event
+
+<https://w3id.org/italia/onto/l0/Event> owl:equivalentClass <http://www.ontologydesignpatterns.org/ont/dul/DUL.owl#Event> .
+
+
+
+###  https://w3id.org/italia/onto/l0/Location
+
+<https://w3id.org/italia/onto/l0/Location> owl:equivalentClass <http://www.ontologydesignpatterns.org/ont/d0.owl#Location> .
+
+
+
+###  https://w3id.org/italia/onto/l0/Object
+
+<https://w3id.org/italia/onto/l0/Object> owl:equivalentClass <http://www.ontologydesignpatterns.org/ont/dul/DUL.owl#Object> .
+
+
+
+###  https://w3id.org/italia/onto/l0/System
+
+<https://w3id.org/italia/onto/l0/System> owl:equivalentClass <http://www.ontologydesignpatterns.org/ont/d0.owl#System> .
+
+
+
+###  https://w3id.org/italia/onto/l0/Topic
+
+<https://w3id.org/italia/onto/l0/Topic> owl:equivalentClass <http://www.ontologydesignpatterns.org/ont/d0.owl#Topic> .
 
 
 


### PR DESCRIPTION
minor fixes:
+ fixed references to `<https://w3id.org/italia/onto/l0>`
+ updated references from URI `<http://dati.gov.it/onto/l0-aligns>` to URI `<https://w3id.org/italia/onto/l0-aligns>`
+ updated conventional URI from `<http://dati.gov.it/onto/l0-aligns/> a owl:Ontology` to URI `<https://w3id.org/italia/onto/l0-aligns> a owl:Ontology`