### PR TITLE
typo corrections, URI conventions fixed to w3id

### DIFF
--- a/Ontologie/CPEV/latest/CPEV-AP_IT.ttl
+++ b/Ontologie/CPEV/latest/CPEV-AP_IT.ttl
@@ -9,18 +9,22 @@
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 @prefix prov: <http://www.w3.org/ns/prov#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
-@prefix smapit: <https://w3id.org/italia/onto/SM/> .
+@prefix poiapit: <https://w3id.org/italia/onto/POI/> .
 @prefix potapit: <https://w3id.org/italia/onto/POT/> .
-@base <https://w3id.org/italia/onto/l0> .
+@prefix roapit: <https://w3id.org/italia/onto/RO/> .
+@prefix smapit: <https://w3id.org/italia/onto/SM/> .
+@prefix tiapit: <https://w3id.org/italia/onto/TI/> .
 
-<https://w3id.org/italia/onto/l0> rdf:type owl:Ontology ;
+@base <https://w3id.org/italia/onto/CPEV> .
+
+<https://w3id.org/italia/onto/CPEV> rdf:type owl:Ontology ;
                                   
                                   rdfs:label "Public Events"@en ,
                                              "Eventi Pubblici"@it ;
                                   
                                   dct:issued "2017-12-06"^^xsd:date ;
                                   
-                                  dct:modified "2018-03-13" ;
+                                  dct:modified "2018-06-11" ;
                                   
                                   dc:creator "Agency for Digital Italy - AgID"@en ,
                                              "Institute of Cognitive Sciences and Technologies of the Italian Research Council (CNR) - Semantic Technology Laboratory (STLab)"@en ,
@@ -29,8 +33,8 @@
                                   rdfs:comment "Questa è l'ontologia del profilo applicativo italiano sugli eventi pubblici)"@en ,
                                                "This is the ontology of the Italian application profile for Public Events"@en ;
                                   
-                                  owl:versionInfo "Version 0.2 - 13 March 2018 - Use of w3id.org/italia as base URI"@en ,
-                                                  "Versione 0.2 - 13 Marzo 2018 - Uso di w3id.org/italia come base URI."@it ;
+                                  owl:versionInfo "Version 0.3 - 11 June 2018 - All URI refactorized to w3id.org/italia"@en ,
+                                                  "Versione 0.3 - 13 Giugno 2018 - Rifattorizzati tutti gli URI con uso di w3id.org/italia."@it ;
                                   
                                   dct:license <https://creativecommons.org/licenses/by/4.0/> ;
                                   
@@ -41,7 +45,7 @@
                                               <https://w3id.org/italia/onto/TI> ,
                                               <https://w3id.org/italia/onto/l0> ;
                                   
-                                  owl:versionIRI <https://w3id.org/italia/onto/CPEV/0.2> .
+                                  owl:versionIRI <https://w3id.org/italia/onto/CPEV/0.3> .
 
 
 #################################################################
@@ -114,7 +118,7 @@ xsd:gYear rdf:type rdfs:Datatype .
                         
                         owl:versionInfo "stabile"@it ;
                         
-                        rdfs:isDefinedBy <http://dati.gov.it/onto/cpevapit> ;
+                        rdfs:isDefinedBy <https://w3id.org/italia/onto/CPEV> ;
                         
                         rdfs:domain :PublicEvent ;
                         
@@ -139,7 +143,7 @@ xsd:gYear rdf:type rdfs:Datatype .
              
              owl:versionInfo "stabile"@it ;
              
-             rdfs:isDefinedBy <http://dati.gov.it/onto/cpevapit> ;
+             rdfs:isDefinedBy <https://w3id.org/italia/onto/CPEV> ;
              
              rdfs:domain :CompositePublicEvent ;
              
@@ -164,7 +168,7 @@ xsd:gYear rdf:type rdfs:Datatype .
        
        owl:versionInfo "stabile"@it ;
        
-       rdfs:isDefinedBy <http://dati.gov.it/onto/cpevapit> ;
+       rdfs:isDefinedBy <https://w3id.org/italia/onto/CPEV> ;
        
        rdfs:range :PublicEvent ;
        
@@ -189,7 +193,7 @@ xsd:gYear rdf:type rdfs:Datatype .
                          
                          owl:versionInfo "stabile"@it ;
                          
-                         rdfs:isDefinedBy <http://dati.gov.it/onto/cpevapit> ;
+                         rdfs:isDefinedBy <https://w3id.org/italia/onto/CPEV> ;
                          
                          rdfs:range :PublicEvent ;
                          
@@ -212,7 +216,7 @@ xsd:gYear rdf:type rdfs:Datatype .
               
               owl:versionInfo "stabile"@it ;
               
-              rdfs:isDefinedBy <http://dati.gov.it/onto/cpevapit> ;
+              rdfs:isDefinedBy <https://w3id.org/italia/onto/CPEV> ;
               
               rdfs:range :CompositePublicEvent ;
               
@@ -235,7 +239,7 @@ xsd:gYear rdf:type rdfs:Datatype .
               
               owl:versionInfo "stabile"@it ;
               
-              rdfs:isDefinedBy <http://dati.gov.it/onto/cpevapit> ;
+              rdfs:isDefinedBy <https://w3id.org/italia/onto/CPEV> ;
               
               rdfs:domain :PublicEvent ;
               
@@ -247,7 +251,7 @@ xsd:gYear rdf:type rdfs:Datatype .
 
 potapit:hasOffer rdf:type owl:ObjectProperty ;
                  
-                 rdfs:isDefinedBy potapit: .
+                 rdfs:isDefinedBy <https://w3id.org/italia/onto/POT> .
 
 
 
@@ -255,7 +259,7 @@ potapit:hasOffer rdf:type owl:ObjectProperty ;
 
 potapit:hasTicket rdf:type owl:ObjectProperty ;
                   
-                  rdfs:isDefinedBy potapit: .
+                  rdfs:isDefinedBy <https://w3id.org/italia/onto/POT> .
 
 
 
@@ -263,7 +267,7 @@ potapit:hasTicket rdf:type owl:ObjectProperty ;
 
 <https://w3id.org/italia/onto/RO/holdsRoleInTime> rdf:type owl:ObjectProperty ;
                                                   
-                                                  rdfs:isDefinedBy <https://w3id.org/italia/onto/RO/> .
+                  rdfs:isDefinedBy <https://w3id.org/italia/onto/RO> .
 
 
 
@@ -271,7 +275,7 @@ potapit:hasTicket rdf:type owl:ObjectProperty ;
 
 smapit:hasOnlineContactPoint rdf:type owl:ObjectProperty ;
                              
-                             rdfs:isDefinedBy smapit: .
+                  rdfs:isDefinedBy <https://w3id.org/italia/onto/SM> .
 
 
 
@@ -288,7 +292,7 @@ smapit:hasOnlineContactPoint rdf:type owl:ObjectProperty ;
 
 l0:description rdf:type owl:DatatypeProperty ;
                
-               rdfs:isDefinedBy l0: .
+               rdfs:isDefinedBy <https://w3id.org/italia/onto/l0> .
 
 
 
@@ -296,7 +300,7 @@ l0:description rdf:type owl:DatatypeProperty ;
 
 l0:identifier rdf:type owl:DatatypeProperty ;
               
-              rdfs:isDefinedBy l0: .
+              rdfs:isDefinedBy <https://w3id.org/italia/onto/l0> .
 
 
 
@@ -304,7 +308,7 @@ l0:identifier rdf:type owl:DatatypeProperty ;
 
 l0:name rdf:type owl:DatatypeProperty ;
         
-        rdfs:isDefinedBy l0: .
+              rdfs:isDefinedBy <https://w3id.org/italia/onto/l0> .
 
 
 
@@ -340,7 +344,7 @@ l0:name rdf:type owl:DatatypeProperty ;
                       
                       owl:versionInfo "stabile"@it ;
                       
-                      rdfs:isDefinedBy <http://dati.gov.it/onto/cpevapit> .
+                      rdfs:isDefinedBy <https://w3id.org/italia/onto/CPEV> .
 
 
 
@@ -401,7 +405,7 @@ l0:name rdf:type owl:DatatypeProperty ;
              
              owl:versionInfo "stabile"@it ;
              
-             rdfs:isDefinedBy <http://dati.gov.it/onto/cpevapit> ;
+             rdfs:isDefinedBy <https://w3id.org/italia/onto/CPEV> ;
              
              prov:wasInfluencedBy <http://schema.org/Event> .
 
@@ -428,7 +432,7 @@ l0:name rdf:type owl:DatatypeProperty ;
                      
                      owl:versionInfo "stabile"@it ;
                      
-                     rdfs:isDefinedBy <http://dati.gov.it/onto/cpevapit> ;
+                     rdfs:isDefinedBy <https://w3id.org/italia/onto/CPEV> ;
                      
                      l0:controlledVocabulary <http://dati.gov.it/onto/controlledvocabulary/PublicEvent> ;
                      
@@ -453,7 +457,7 @@ l0:name rdf:type owl:DatatypeProperty ;
                    
                    owl:versionInfo "stabile"@it ;
                    
-                   rdfs:isDefinedBy <http://dati.gov.it/onto/cpevapit> .
+                   rdfs:isDefinedBy <https://w3id.org/italia/onto/CPEV> .
 
 
 
@@ -466,7 +470,7 @@ l0:name rdf:type owl:DatatypeProperty ;
                                                                      owl:allValuesFrom :PublicEvent
                                                                    ] ;
                                                    
-                                                   rdfs:isDefinedBy <http://dati.gov.it/onto/poiapit> .
+                                                   rdfs:isDefinedBy <https://w3id.org/italia/onto/POI> .
 
 
 
@@ -474,7 +478,7 @@ l0:name rdf:type owl:DatatypeProperty ;
 
 potapit:Offer rdf:type owl:Class ;
               
-              rdfs:isDefinedBy potapit: .
+              rdfs:isDefinedBy <https://w3id.org/italia/onto/POT> .
 
 
 
@@ -482,7 +486,7 @@ potapit:Offer rdf:type owl:Class ;
 
 potapit:Ticket rdf:type owl:Class ;
                
-               rdfs:isDefinedBy potapit: .
+               rdfs:isDefinedBy <https://w3id.org/italia/onto/POT> .
 
 
 
@@ -490,7 +494,7 @@ potapit:Ticket rdf:type owl:Class ;
 
 <https://w3id.org/italia/onto/RO/TimeIndexedRole> rdf:type owl:Class ;
                                                   
-                                                  rdfs:isDefinedBy <https://w3id.org/italia/onto/RO/> .
+                                                  rdfs:isDefinedBy <https://w3id.org/italia/onto/RO> .
 
 
 
@@ -498,7 +502,7 @@ potapit:Ticket rdf:type owl:Class ;
 
 smapit:OnlineContactPoint rdf:type owl:Class ;
                           
-                          rdfs:isDefinedBy smapit: .
+                          rdfs:isDefinedBy <https://w3id.org/italia/onto/SM> .
 
 
 
@@ -506,7 +510,7 @@ smapit:OnlineContactPoint rdf:type owl:Class ;
 
 ti:TimeIndexedEvent rdf:type owl:Class ;
                     
-                    rdfs:isDefinedBy ti: .
+                    rdfs:isDefinedBy <https://w3id.org/italia/onto/TI> .
 
 
 


### PR DESCRIPTION
+ fixed `<https://w3id.org/italia/onto/l0> a owl:Ontology` to `<https://w3id.org/italia/onto/CPEV> a owl:Ontology`

+ fixed `<http://dati.gov.it/onto/cpevapit>` to `<https://w3id.org/italia/onto/CPEV>`

+ fixed 
```
rdfs:isDefinedBy <https://w3id.org/italia/onto/POI> .
rdfs:isDefinedBy <https://w3id.org/italia/onto/POT> .
rdfs:isDefinedBy <https://w3id.org/italia/onto/RO> .
rdfs:isDefinedBy <https://w3id.org/italia/onto/SM> .
rdfs:isDefinedBy <https://w3id.org/italia/onto/TI> .
```