### PR TITLE
fixed - cofog-2009

### DIFF
--- a/VocabolariControllati/classifications-for-organizations/cofog-2009/cofog-2009.ttl
+++ b/VocabolariControllati/classifications-for-organizations/cofog-2009/cofog-2009.ttl
@@ -176,7 +176,7 @@ vcard:hasEmail a rdfs:Property .
     dct:identifier "ISTAT" ;
     foaf:name "Istituto Nazionale di Statistica - ISTAT"@it , "Italian National Institute of Statistics - ISTAT"@en .
 
-<http://spcdata.digitpa.gov.it/browse/page/Amministrazione/agid>
+<http://spcdata.digitpa.gov.it/Amministrazione/agid>
     a dcatapit:Agent, foaf:Agent , prov:Agent ;
     dct:identifier "agid" ;
     foaf:name "Agenzia per l'Italia Digitale"@it , "Italian Digital Agency"@en .


### PR DESCRIPTION
é stata corretta l'uri di `agid` da `<http://spcdata.digitpa.gov.it/browse/page/Amministrazione/agid>` a `<http://spcdata.digitpa.gov.it/Amministrazione/agid>`, attendiamo la validazione.