### PR TITLE
fixed - S13

### DIFF
--- a/VocabolariControllati/classifications-for-organizations/S13/S13.ttl
+++ b/VocabolariControllati/classifications-for-organizations/S13/S13.ttl
@@ -178,7 +178,7 @@ covapit:PublicOrganizationCategory a rdfs:Class .
     dct:identifier "ISTAT" ;
     foaf:name "Istituto Nazionale di Statistica - ISTAT"@it , "Italian National Institute of Statistics - ISTAT"@en .
 
-<http://spcdata.digitpa.gov.it/browse/page/Amministrazione/agid>
+<http://spcdata.digitpa.gov.it/Amministrazione/agid>
     a dcatapit:Agent, foaf:Agent , prov:Agent ;
     dct:identifier "agid" ;
     foaf:name "Agenzia per l'Italia Digitale"@it , "Italian Digital Agency"@en .


### PR DESCRIPTION
é stata corretta l'uri di `agid` da `<http://spcdata.digitpa.gov.it/browse/page/Amministrazione/agid>` a `<http://spcdata.digitpa.gov.it/Amministrazione/agid>`, attendiamo la validazione.