### PR TITLE
added maven descriptor

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,41 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+	<modelVersion>4.0.0</modelVersion>
+	<groupId>com.github.italia</groupId>
+	<artifactId>daf-ontologie-vocabolari-controllati</artifactId>
+	<packaging>jar</packaging>
+	<version>0.1-SNAPSHOT</version>
+	<name>daf-ontologie-vocabolari-controllati</name>
+	<url>https://github.com/italia/daf-ontologie-vocabolari-controllati</url>
+
+	<properties>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+	</properties>
+
+	<build>
+
+	<resources>
+      		<resource>
+        		<directory>.</directory>
+		        <filtering>false</filtering>
+			<excludes>
+				<exclude>Presentazioni/**</exclude>
+				<exclude>OntoPiA.png</exclude>
+			</excludes>
+      		</resource>
+	</resources>
+
+	<plugins>
+		<plugin>
+			<groupId>org.apache.maven.plugins</groupId>
+			<artifactId>maven-resources-plugin</artifactId>
+			<version>3.1.0</version>
+			<configuration>
+				<encoding>UTF-8</encoding>
+			</configuration>
+		</plugin>
+	</plugins>
+
+	</build>
+
+</project>


### PR DESCRIPTION
Adding a default maven descriptor, is possible to handle the RDF files (ontologies, controlled vocabularies) as resources inside a jar, for java, Scala, JVM-based projects.
In particular we may use jitpack: https://jitpack.io/#italia/daf-ontologie-vocabolari-controllati, without the need of of rebuilding locally an artifact, and managing versions (it will use directly the updated git branch/hash).