### PR TITLE
Validate ontologies and vocabularies using shacl.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -66,7 +66,7 @@ repos:
     name: pyshacl ontologies
     entry: python -m dati_playground validate --validate-shacl=true
     exclude: >-
-      .*-aligns.*
+      .*(-aligns|-DBGT|example).*
     files: >-
       ^Ontologie\/[^/]+\/latest/.*\.ttl
     types:
@@ -78,7 +78,7 @@ repos:
     name: Ontologies latest validator
     entry: python -m dati_playground validate --validate-versioned-directory=true
     exclude: >-
-      .*-aligns.*
+      .*(-aligns|-DBGT|example).*
     files: >-
       ^Ontologie\/.*\.ttl
     language: python

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -65,6 +65,8 @@ repos:
   - id: onto-pyshacl
     name: pyshacl ontologies
     entry: python -m dati_playground validate --validate-shacl=true
+    exclude: >-
+      .*-aligns.*
     files: >-
       ^Ontologie\/[^/]+\/latest/.*\.ttl
     types:
@@ -75,6 +77,8 @@ repos:
   - id: onto-latest
     name: Ontologies latest validator
     entry: python -m dati_playground validate --validate-versioned-directory=true
+    exclude: >-
+      .*-aligns.*
     files: >-
       ^Ontologie\/.*\.ttl
     language: python

--- a/Ontologie/rules.shacl
+++ b/Ontologie/rules.shacl
@@ -1,0 +1,76 @@
+#
+# Validate Ontologies.
+#
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix dct:     <http://purl.org/dc/terms/> .
+@prefix adms:    <http://www.w3.org/ns/adms#> .
+@prefix rdfs:    <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix owl:     <http://www.w3.org/2002/07/owl#> .
+@prefix rdf:     <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix dc:      <http://purl.org/dc/elements/1.1/> .
+@prefix skos:    <http://www.w3.org/2004/02/skos/core#> .
+@prefix cpvapit: <https://w3id.org/italia/onto/CPV/> .
+@prefix xkos:    <http://rdf-vocabulary.ddialliance.org/xkos#> .
+@prefix clvapit: <https://w3id.org/italia/onto/CLV/> .
+@prefix admsapit: <https://w3id.org/italia/onto/ADMS/> .
+@prefix dcatapit: <http://dati.gov.it/onto/dcatapit#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix vcard: <http://www.w3.org/2006/vcard/ns#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix ndc: <https://w3id.org/italia/onto/NDC/> .
+@prefix ex: <https://localhost.example/OntologyShacl> .
+
+ex:
+ a owl:Ontology ;
+  sh:declare [
+    sh:prefix "skos" ;
+    sh:namespace "http://www.w3.org/2004/02/skos/core#"^^xsd:anyURI ;
+  ] ;
+
+  sh:declare [
+      sh:prefix "dcatapit" ;
+      sh:namespace "http://dati.gov.it/onto/dcatapit#"^^xsd:anyURI ;
+  ] ;
+.
+
+ex:VocabularyShape
+  a sh:NodeShape ;
+
+  sh:target [
+    a sh:SPARQLTarget ;
+    sh:prefixes ex: ;
+    sh:select """
+      SELECT ?this
+      WHERE {
+        ?this rdf:type owl:Ontology .
+      }
+      """ ;
+  ];
+
+  # Required elements.
+  sh:property [ sh:path owl:versionIRI                   ; sh:minCount 1 ; ] ;
+  sh:property [ sh:path owl:versionInfo                   ; sh:minCount 1 ; ] ;
+  sh:property [ sh:path admsapit:acronym                   ; sh:minCount 1 ; ] ;
+  sh:property [ sh:path admsapit:hasKeyClass                   ; sh:minCount 1 ; ] ;
+  sh:property [ sh:path admsapit:hasSemanticAssetDistribution                   ; sh:minCount 1 ; ] ;
+  sh:property [ sh:path admsapit:prefix                   ; sh:minCount 1 ; ] ;
+  sh:property [ sh:path admsapit:status                   ; sh:minCount 1 ; ] ;
+  
+  sh:property [ sh:path dct:identifier ; sh:minCount 1 ; ] ;
+  sh:property [ sh:path dct:title ; sh:minCount 1 ; ] ;
+  sh:property [ sh:path dct:description ; sh:minCount 1 ; ] ;
+
+  sh:property [ sh:path dct:issued; sh:minCount 1 ; ] ;
+  sh:property [ sh:path dct:modified; sh:minCount 1 ; ] ;
+  sh:property [ sh:path dct:creator                   ; sh:minCount 1 ; ] ;
+  sh:property [ sh:path dct:rightsHolder ; sh:minCount 1 ; ] ;
+  sh:property [ sh:path dct:publisher ; sh:minCount 1 ; ] ;
+  sh:property [ sh:path dct:accrualPeriodicity ; sh:minCount 1 ; ] ;
+
+  sh:property [ sh:path dcat:theme; sh:minCount 1 ; ] ;
+  sh:property [ sh:path dcat:distribution; sh:minCount 1 ; ] ;
+
+  # Optional elements, but required for publication in NDC.
+  sh:property [ sh:path dcat:keyword; sh:minCount 1 ; ] ;
+  .

--- a/Ontologie/rules.shacl
+++ b/Ontologie/rules.shacl
@@ -52,12 +52,10 @@ ex:VocabularyShape
   sh:property [ sh:path owl:versionIRI                   ; sh:minCount 1 ; ] ;
   sh:property [ sh:path owl:versionInfo                   ; sh:minCount 1 ; ] ;
   sh:property [ sh:path admsapit:acronym                   ; sh:minCount 1 ; ] ;
-  sh:property [ sh:path admsapit:hasKeyClass                   ; sh:minCount 1 ; ] ;
   sh:property [ sh:path admsapit:hasSemanticAssetDistribution                   ; sh:minCount 1 ; ] ;
   sh:property [ sh:path admsapit:prefix                   ; sh:minCount 1 ; ] ;
-  sh:property [ sh:path admsapit:status                   ; sh:minCount 1 ; ] ;
+  # FIXME re-enable. sh:property [ sh:path admsapit:status                   ; sh:minCount 1 ; ] ;
   
-  sh:property [ sh:path dct:identifier ; sh:minCount 1 ; ] ;
   sh:property [ sh:path dct:title ; sh:minCount 1 ; ] ;
   sh:property [ sh:path dct:description ; sh:minCount 1 ; ] ;
 
@@ -69,8 +67,14 @@ ex:VocabularyShape
   sh:property [ sh:path dct:accrualPeriodicity ; sh:minCount 1 ; ] ;
 
   sh:property [ sh:path dcat:theme; sh:minCount 1 ; ] ;
-  sh:property [ sh:path dcat:distribution; sh:minCount 1 ; ] ;
 
   # Optional elements, but required for publication in NDC.
   sh:property [ sh:path dcat:keyword; sh:minCount 1 ; ] ;
+  
+  # To be added in the future.
+  # sh:property [ sh:path dct:identifier ; sh:minCount 1 ; ] ;
+
+  # Optional elements, not required.
+  # sh:property [ sh:path admsapit:hasKeyClass                   ; sh:minCount 1 ; ] ;
+  # sh:property [ sh:path dcat:distribution ; sh:minCount 1 ; ] ;
   .

--- a/VocabolariControllati/rules.shacl
+++ b/VocabolariControllati/rules.shacl
@@ -1,0 +1,70 @@
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix dct:     <http://purl.org/dc/terms/> .
+@prefix adms:    <http://www.w3.org/ns/adms#> .
+@prefix rdfs:    <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix owl:     <http://www.w3.org/2002/07/owl#> .
+@prefix rdf:     <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix dc:      <http://purl.org/dc/elements/1.1/> .
+@prefix skos:    <http://www.w3.org/2004/02/skos/core#> .
+@prefix cpvapit: <https://w3id.org/italia/onto/CPV/> .
+@prefix xkos:    <http://rdf-vocabulary.ddialliance.org/xkos#> .
+@prefix clvapit: <https://w3id.org/italia/onto/CLV/> .
+@prefix dcatapit: <http://dati.gov.it/onto/dcatapit#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix vcard: <http://www.w3.org/2006/vcard/ns#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix ndc: <https://w3id.org/italia/onto/NDC/> .
+@prefix ex: <https://localhost.example/> .
+
+ex:
+ a owl:Ontology ;
+  sh:declare [
+    sh:prefix "skos" ;
+    sh:namespace "http://www.w3.org/2004/02/skos/core#"^^xsd:anyURI ;
+  ] ;
+
+  sh:declare [
+      sh:prefix "dcatapit" ;
+      sh:namespace "http://dati.gov.it/onto/dcatapit#"^^xsd:anyURI ;
+  ] ;
+.
+
+ex:VocabularyShape
+  a sh:NodeShape ;
+
+  # Use advanced shacl features to
+  #   identify a target: https://www.w3.org/TR/shacl-af/
+  sh:target [
+    a sh:SPARQLTarget ;
+    sh:prefixes ex: ;
+    sh:select """
+      SELECT ?this
+      WHERE {
+        ?this a skos:ConceptScheme .
+        ?this a dcatapit:Dataset .
+      }
+      """ ;
+  ];
+
+  # Required elements according to
+  #   https://docs.italia.it/italia/daf/linee-guida-cataloghi-dati-dcat-ap-it
+  sh:property [ sh:path dct:identifier ; sh:minCount 1 ; ] ;
+  sh:property [ sh:path dct:title ; sh:minCount 1 ; ] ;
+  sh:property [ sh:path dct:description ; sh:minCount 1 ; ] ;
+  sh:property [ sh:path dct:modified; sh:minCount 1 ; ] ;
+  sh:property [ sh:path dcat:theme; sh:minCount 1 ; ] ;
+  sh:property [ sh:path dct:rightsHolder ; sh:minCount 1 ; ] ;
+  sh:property [ sh:path dct:accrualPeriodicity ; sh:minCount 1 ; ] ;
+  sh:property [ sh:path dcat:distribution; sh:minCount 1 ; ] ;
+
+
+  # TODO: recommended elements
+  #  see https://docs.italia.it/italia/daf/linee-guida-cataloghi-dati-dcat-ap-it/it/stabile/dataset_elementi_raccomandati.html
+  
+  
+  # Optional elements, but required for publication in NDC.
+  sh:property [ sh:path dcat:keyword; sh:minCount 1 ; ] ;
+  sh:property [ sh:path owl:versionInfo; sh:minCount 1 ; ] ;
+  sh:property [ sh:path ndc:keyConcept; sh:minCount 1 ; ] ;
+  .


### PR DESCRIPTION
## This PR

- adds rules.shacl validators, that are interpreted from the CI
- not all checks are enabled
- address some ontologies issues. #117 