### PR TITLE
Fix broken CI adding a dependency in tox.ini

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -7,6 +7,7 @@ deps =
   pytest
   pytest-parallel
   requests
+  py
 
 # Uncomment here to set an extra PIP_INDEX_URL
 # setenv =


### PR DESCRIPTION
## This PR

- fixes the CI


## It is done

- adding `py` to the dependencies.

See https://github.com/kevlened/pytest-parallel/issues/118