### PR TITLE
fix(ci): properly check `latest` ontology directories

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -51,8 +51,8 @@ repos:
   rev: v1.3.0
   hooks:
     - id: python-safety-dependencies-check
-- repo: https://github.com/teamdigitale/json-semantic-playground.git
-  rev: 30fef4df
+- repo: https://github.com/bfabio/json-semantic-playground.git
+  rev: dd63501
   hooks:
   -   id: validate-csv
       files: >-
@@ -61,7 +61,7 @@ repos:
         ^.*(scriptR2RML|vocs-deprecated).*
   -   id: validate-directory-versioning
       files: >-
-        ^Ontologie/.*/latest/.*\.ttl
+        ^Ontologie/.*
   -   id: validate-turtle
       name: validate-turtle-ontologies
       files: >-


### PR DESCRIPTION
Fail if the contents of the `latest` dir in an ontology don't exactly match the latest versioned directory.